### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Client structure has been designed to mirror API provided by the [official pytho
 
    ```yaml
    dependencies:
-     crystal-docker:
+     docker:
        github: aca-labs/crystal-docker
    ```
 


### PR DESCRIPTION
The package should be named `docker` to properly import it.